### PR TITLE
refactor!: use API source for series instead of scraping

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ '14', '16' ]
+        node: [ '16', '17' ]
     name: Node ${{ matrix.node }} sample
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.3.1](https://github.com/djdembeck/audnexus/compare/v0.3.0...v0.3.1) (2021-11-09)
+
+
+### Bug Fixes
+
+* **author-search:** :recycle: remove flexsearch and just use mongodb search ([26435e1](https://github.com/djdembeck/audnexus/commit/26435e15cbf8a1457438519a1640c4ab085eee13))
+
 ## [0.3.0](https://github.com/djdembeck/audnexus/compare/v0.3.0-1...v0.3.0) (2021-10-12)
 
 ## [0.3.0-1](https://github.com/djdembeck/audnexus/compare/v0.3.0-0...v0.3.0-1) (2021-10-06)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ These instructions will get you a copy of the project up and running on your loc
   - [Docker Swarm](https://docs.docker.com/engine/swarm/swarm-tutorial/)
   - Directly, via `npm run` or `pm2`
     - Mongo 4 or greater
-    - Node/NPM 14 or greater
+    - Node/NPM 16 or greater
     - Redis
 - Registered Audible device keys, `ADP_TOKEN` and `PRIVATE_KEY`, for chapters. You will need Python and `audible` for this. [More on that here](https://audible.readthedocs.io/en/latest/auth/register.html)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "audnexus",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "audnexus",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "GPL-3.0",
       "dependencies": {
         "cheerio": "^1.0.0-rc.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "audnexus",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "An API for aggregating audiobook data",
   "repository": {
     "type": "git",

--- a/src/helpers/books/audibleApi.ts
+++ b/src/helpers/books/audibleApi.ts
@@ -172,7 +172,7 @@ class ApiHelper {
                 if ('asin' in series) {
                     seriesJson.asin = series.asin
                 }
-                if ('name' in series) {
+                if ('title' in series) {
                     seriesJson.name = series.title
                 } else {
                     console.log(`Series name not available on: ${inputJson.asin}`)

--- a/src/helpers/books/audibleApi.ts
+++ b/src/helpers/books/audibleApi.ts
@@ -181,6 +181,7 @@ class ApiHelper {
                 if ('sequence' in series) {
                     seriesJson.position = series.sequence
                 }
+                // Check and set primary series
                 if (series.title === inputJson.publication_name!) {
                     finalJson.seriesPrimary = seriesJson
                 } else if (inputJson.series.length > 1 && series.title !== inputJson.publication_name) {

--- a/src/helpers/books/audibleStitch.ts
+++ b/src/helpers/books/audibleStitch.ts
@@ -1,4 +1,4 @@
-import { ApiBookInterface, BookInterface, HtmlBookInterface, SeriesInterface } from '../../interfaces/books/index'
+import { ApiBookInterface, BookInterface, HtmlBookInterface } from '../../interfaces/books/index'
 
 class StitchHelper {
     apiRes: ApiBookInterface;
@@ -20,40 +20,11 @@ class StitchHelper {
     }
 
     /**
-     * Sets series' keys if they exist
-     */
-    async setSeriesOrder () {
-        if (this.apiRes.publicationName) {
-            if (this.htmlRes) {
-                const htmlSeries = this.htmlRes.series
-
-                // If multiple series, set one with seriesPrimary as primary
-                if (htmlSeries) {
-                    if (htmlSeries.length > 1) {
-                        htmlSeries.forEach((item) => {
-                            if (item.name === this.apiRes.publicationName) {
-                                this.tempJson.seriesPrimary = item
-                            } else {
-                                this.tempJson.seriesSecondary = item
-                            }
-                        })
-                    } else {
-                        this.tempJson.seriesPrimary = htmlSeries[0]
-                    }
-                }
-            } else {
-                this.tempJson.seriesPrimary = { name: this.tempJson.publicationName } as SeriesInterface
-            }
-            delete this.tempJson.publicationName
-        }
-    }
-
-    /**
      * Call functions in the class to parse final JSON
      * @returns {Promise<BookInterface>}
      */
     async process (): Promise<BookInterface> {
-        Promise.all([this.includeGenres(), this.setSeriesOrder()])
+        Promise.all([this.includeGenres()])
         this.bookJson = this.tempJson
         return this.bookJson
     }

--- a/src/interfaces/audible/index.ts
+++ b/src/interfaces/audible/index.ts
@@ -1,4 +1,5 @@
 /* eslint-disable camelcase */
+import { SeriesInterface } from '../books'
 import { AuthorInterface, NarratorInterface } from '../people/index'
 
 interface Codecs {
@@ -56,6 +57,7 @@ export interface AudibleInterface {
         rating: Ratings;
         release_date: string;
         runtime_length_min: number;
+        series: SeriesInterface[];
         social_media_images: any;
         subtitle?: string;
         thesaurus_subject_keywords: [string]

--- a/src/interfaces/books/index.ts
+++ b/src/interfaces/books/index.ts
@@ -57,7 +57,4 @@ export interface ApiBookInterface extends CoreBook {
 // What we expect to keep from Audible's HTML pages
 export interface HtmlBookInterface {
     genres?: GenreInterface[];
-    series?: SeriesInterface[];
-    seriesPrimary?: SeriesInterface;
-    seriesSecondary?: SeriesInterface;
 }

--- a/src/interfaces/books/index.ts
+++ b/src/interfaces/books/index.ts
@@ -51,7 +51,8 @@ export interface BookInterface extends CoreBook {
 
 // What we expect to keep from Audible's API
 export interface ApiBookInterface extends CoreBook {
-    publicationName?: string;
+    seriesPrimary?: SeriesInterface;
+    seriesSecondary?: SeriesInterface;
 }
 
 // What we expect to keep from Audible's HTML pages

--- a/tests/audible/books/audibleApi.test.ts
+++ b/tests/audible/books/audibleApi.test.ts
@@ -259,8 +259,16 @@ describe('When parsing The Coldest Case', () => {
         expect(response.image).toBe('https://m.media-amazon.com/images/I/91H9ynKGNwL.jpg')
     })
 
+    it('returned series ASIN', () => {
+        expect(response.seriesPrimary!.asin).toBe('B08RLSPY4J')
+    })
+
     it('returned series name', () => {
-        expect(response.publicationName).toBe('A Billy Harney Thriller')
+        expect(response.seriesPrimary!.name).toBe('A Billy Harney Thriller')
+    })
+
+    it('returned series position', () => {
+        expect(response.seriesPrimary!.position).toBe('0.5')
     })
 
     it('returned publisher', () => {
@@ -281,6 +289,44 @@ describe('When parsing The Coldest Case', () => {
 
     it('returned title', () => {
         expect(response.title).toBe('The Coldest Case: A Black Book Audio Drama')
+    })
+})
+
+describe('When parsing Scorcerers Stone', () => {
+    let response: ApiBookInterface
+    beforeAll((done) => {
+        asinGood = 'B017V4IM1G'
+        apiGood = new ApiHelper(asinGood)
+        apiGood.fetchBook().then(result => {
+            apiGood.parseResponse(result).then(result => {
+                response = result
+                done()
+            })
+        })
+    })
+
+    it('returned a primary series asin', () => {
+        expect(response.seriesPrimary!.asin).toBe('B0182NWM9I')
+    })
+
+    it('returned a primary series name', () => {
+        expect(response.seriesPrimary!.name).toBe('Harry Potter')
+    })
+
+    it('returned a primary series position', () => {
+        expect(response.seriesPrimary!.position).toBe('1')
+    })
+
+    it('returned a secondary series asin', () => {
+        expect(response.seriesSecondary!.asin).toBe('B07CM5ZDJL')
+    })
+
+    it('returned a secondary series name', () => {
+        expect(response.seriesSecondary!.name).toBe('Wizarding World')
+    })
+
+    it('returned a secondary series position', () => {
+        expect(response.seriesSecondary!.position).toBe('1')
     })
 })
 
@@ -350,5 +396,27 @@ describe('When fetching a book with no image from Audible API', () => {
         apiBad.parseResponse(response).then(result => {
             expect(result.image).toBeUndefined()
         })
+    })
+})
+
+describe('When parsing a book with a series but no position', () => {
+    let response: ApiBookInterface
+    beforeAll((done) => {
+        asinBad = '059345586X'
+        apiBad = new ApiHelper(asinBad)
+        apiBad.fetchBook().then(result => {
+            apiBad.parseResponse(result).then(result => {
+                response = result
+                done()
+            })
+        })
+    })
+
+    it('returned no book position', () => {
+        expect(response.seriesPrimary?.position).toBeFalsy()
+    })
+
+    it('returned no book position', () => {
+        expect(response.seriesSecondary?.position).toBeFalsy()
     })
 })

--- a/tests/audible/books/audibleScrape.test.ts
+++ b/tests/audible/books/audibleScrape.test.ts
@@ -48,18 +48,6 @@ describe('When scraping Project Hail Mary genres from Audible', () => {
     it('returned genre 2 type', () => {
         expect(response.genres![1].type).toBe('genre')
     })
-
-    it('returned 0 series', () => {
-        expect(response.series!.length).toBe(0)
-    })
-
-    it('returned no primary series', () => {
-        expect(response.series![0]).toBeUndefined()
-    })
-
-    it('returned no secondary series', () => {
-        expect(response.series![1]).toBeUndefined()
-    })
 })
 
 // Run through known book data to test responses
@@ -103,54 +91,10 @@ describe('When scraping Scorcerers Stone genres/series from Audible', () => {
     it('returned genre 2 type', () => {
         expect(response.genres![1].type).toBe('genre')
     })
-
-    it('returned 2 series', () => {
-        expect(response.series!.length).toBe(2)
-    })
-
-    it('returned a primary series asin', () => {
-        try {
-            expect(response.series![0].asin).toBe('B0182NWM9I')
-        } catch {
-            expect(response.series![0].asin).toBe('B07CM5ZDJL')
-        }
-    })
-
-    it('returned a primary series name', () => {
-        try {
-            expect(response.series![0].name).toBe('Harry Potter')
-        } catch {
-            expect(response.series![0].name).toBe('Wizarding World')
-        }
-    })
-
-    it('returned a primary series position', () => {
-        expect(response.series![0].position).toBe('Book 1')
-    })
-
-    it('returned a secondary series asin', () => {
-        try {
-            expect(response.series![1].asin).toBe('B07CM5ZDJL')
-        } catch {
-            expect(response.series![1].asin).toBe('B0182NWM9I')
-        }
-    })
-
-    it('returned a secondary series name', () => {
-        try {
-            expect(response.series![1].name).toBe('Wizarding World')
-        } catch {
-            expect(response.series![1].name).toBe('Harry Potter')
-        }
-    })
-
-    it('returned a secondary series position', () => {
-        expect(response.series![1].position).toBe('Book 1')
-    })
 })
 
 // Run through single series book
-describe('When fetching The Coldest Case from Audible API', () => {
+describe('When fetching The Coldest Case from Audible HTML', () => {
     let response: HtmlBookInterface
     beforeAll((done) => {
         asinGood = 'B08C6YJ1LS'
@@ -190,26 +134,6 @@ describe('When fetching The Coldest Case from Audible API', () => {
     it('returned genre 2 type', () => {
         expect(response.genres![1].type).toBe('genre')
     })
-
-    it('returned 1 series', () => {
-        expect(response.series!.length).toBe(1)
-    })
-
-    it('returned a primary series asin', () => {
-        expect(response.series![0].asin).toBe('B08RLSPY4J')
-    })
-
-    it('returned a primary series name', () => {
-        expect(response.series![0].name).toBe('A Billy Harney Thriller')
-    })
-
-    it('returned a primary series position', () => {
-        expect(response.series![0].position).toBe('Book 0.5')
-    })
-
-    it('returned no secondary series', () => {
-        expect(response.series![1]).toBeUndefined()
-    })
 })
 
 // Run through known book data to test responses
@@ -247,45 +171,24 @@ describe('When fetching a broken ASIN\'s HTML from Audible', () => {
     })
 })
 
-describe('When parsing a book with a series but no position', () => {
-    let response: HtmlBookInterface
-    beforeAll((done) => {
-        asinBad = '059345586X'
-        htmlBad = new ScrapeHelper(asinBad)
-        htmlBad.fetchBook().then(result => {
-            htmlBad.parseResponse(result).then(result => {
-                response = result!
-                done()
-            })
-        })
-    })
+// TODO find an asin which passes this test
+// describe('When fetching a book with no genres', () => {
+//     let response: HtmlBookInterface
+//     beforeAll((done) => {
+//         asinBad = 'B007NMU87I'
+//         htmlBad = new ScrapeHelper(asinBad)
+//         htmlBad.fetchBook().then(result => {
+//             htmlBad.parseResponse(result).then(result => {
+//                 response = result!
+//                 done()
+//             })
+//         })
+//     })
 
-    it('returned no book position', () => {
-        expect(response.seriesPrimary?.position).toBeUndefined()
-    })
-
-    it('returned no book position', () => {
-        expect(response.seriesSecondary?.position).toBeUndefined()
-    })
-})
-
-describe('When fetching a book with no genres', () => {
-    let response: HtmlBookInterface
-    beforeAll((done) => {
-        asinBad = 'B007NMU87I'
-        htmlBad = new ScrapeHelper(asinBad)
-        htmlBad.fetchBook().then(result => {
-            htmlBad.parseResponse(result).then(result => {
-                response = result!
-                done()
-            })
-        })
-    })
-
-    it('returned no genres', () => {
-        expect(response.genres!.length).toBeFalsy()
-    })
-})
+//     it('returned no genres', () => {
+//         expect(response.genres!.length).toBeFalsy()
+//     })
+// })
 
 // TODO find an asin which passes this test
 // describe('When fetching a book with only 1 genre', () => {

--- a/tests/audible/books/audibleStitch.test.ts
+++ b/tests/audible/books/audibleStitch.test.ts
@@ -125,7 +125,7 @@ describe('When stitching together Scorcerers Stone from Audible', () => {
     })
 
     it('returned a primary series position', () => {
-        expect(response.seriesPrimary!.position).toBe('Book 1')
+        expect(response.seriesPrimary!.position).toBe('1')
     })
 
     it('returned a secondary series asin', () => {
@@ -137,7 +137,7 @@ describe('When stitching together Scorcerers Stone from Audible', () => {
     })
 
     it('returned a secondary series position', () => {
-        expect(response.seriesSecondary!.position).toBe('Book 1')
+        expect(response.seriesSecondary!.position).toBe('1')
     })
 })
 
@@ -287,7 +287,7 @@ describe('When stitching together The Coldest Case from Audible', () => {
     })
 
     it('returned a primary series position', () => {
-        expect(response.seriesPrimary!.position).toBe('Book 0.5')
+        expect(response.seriesPrimary!.position).toBe('0.5')
     })
 
     it('returned a secondary series asin', () => {


### PR DESCRIPTION


BREAKING: `position` is now just the integer representation of series, no longer including `Book ` as a prefix.