### PR TITLE
feat: enable basic rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The stack defaults to 15 replicas for the node-server container. Customize this 
 Environment variables to add:
 
 - `NODE_ADP_TOKEN`: Aforementioned `ADP_TOKEN` value
+- `NODE_MAX_REQUESTS`: Maximum amount of requests per 1 minute period from a single source (default 100)
 - `NODE_MONGODB_URI`: MongoDB connection URL, such as `mongodb://mongo/audnexus`
 - `NODE_PRIVATE_KEY`: Aforementioned `PRIVATE_KEY` value
 - `NODE_REDIS_URL`: Redis connection URL, such as `redis://redis:6379`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,17 @@
-version: "3.7"
+version: '3.7'
 
 services:
   node-server:
     image: ghcr.io/laxamentumtech/audnexus:develop
     restart: always
     environment:
-    - ADP_TOKEN=${NODE_ADP_TOKEN}
-    - MONGODB_URI=${NODE_MONGODB_URI}
-    - PRIVATE_KEY=${NODE_PRIVATE_KEY}
-    - REDIS_URL=${NODE_REDIS_URL}
+      - ADP_TOKEN=${NODE_ADP_TOKEN}
+      - MAX_REQUESTS=${NODE_MAX_REQUESTS}
+      - MONGODB_URI=${NODE_MONGODB_URI}
+      - PRIVATE_KEY=${NODE_PRIVATE_KEY}
+      - REDIS_URL=${NODE_REDIS_URL}
     ports:
-      - "3000:3000"
+      - '3000:3000'
     depends_on:
       - mongo
       - redis
@@ -19,12 +20,12 @@ services:
       - internal
     deploy:
       labels:
-        - "traefik.enable=true"
-        - "traefik.docker.network=traefik-overlay"
-        - "traefik.http.routers.node-server.rule=Host(`${TRAEFIK_DOMAIN}`)"
-        - "traefik.http.routers.node-server.entrypoints=websecure"
-        - "traefik.http.routers.redirs.entrypoints=websecure"
-        - "traefik.http.services.node-server.loadbalancer.server.port=3000"
+        - 'traefik.enable=true'
+        - 'traefik.docker.network=traefik-overlay'
+        - 'traefik.http.routers.node-server.rule=Host(`${TRAEFIK_DOMAIN}`)'
+        - 'traefik.http.routers.node-server.entrypoints=websecure'
+        - 'traefik.http.routers.redirs.entrypoints=websecure'
+        - 'traefik.http.services.node-server.loadbalancer.server.port=3000'
       replicas: 15
 
   mongo:
@@ -45,15 +46,15 @@ services:
     image: traefik:v2.8
     restart: always
     command:
-      - "--providers.docker=true"
-      - "--entryPoints.websecure.address=:443"
-      - "--providers.docker.exposedbydefault=false"
-      - "--entrypoints.websecure.http.tls=true"
-      - "--certificatesresolvers.myresolver.acme.tlschallenge=true"
-      - "--certificatesresolvers.myresolver.acme.email=${TRAEFIK_EMAIL}"
-      - "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
+      - '--providers.docker=true'
+      - '--entryPoints.websecure.address=:443'
+      - '--providers.docker.exposedbydefault=false'
+      - '--entrypoints.websecure.http.tls=true'
+      - '--certificatesresolvers.myresolver.acme.tlschallenge=true'
+      - '--certificatesresolvers.myresolver.acme.email=${TRAEFIK_EMAIL}'
+      - '--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json'
     ports:
-      - "443:443"
+      - '443:443'
     volumes:
       - /mnt/docker/letsencrypt:/letsencrypt
       - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 	"license": "GPL-3.0",
 	"dependencies": {
 		"@fastify/cors": "8.1.0",
+		"@fastify/rate-limit": "^7.4.0",
 		"@fastify/redis": "6.0.0",
 		"cheerio": "1.0.0-rc.12",
 		"domhandler": "5.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,6 +2,7 @@ lockfileVersion: 5.4
 
 specifiers:
   '@fastify/cors': 8.1.0
+  '@fastify/rate-limit': ^7.4.0
   '@fastify/redis': 6.0.0
   '@jest/types': 29.0.1
   '@types/html-to-text': 8.1.1
@@ -39,6 +40,7 @@ specifiers:
 
 dependencies:
   '@fastify/cors': 8.1.0
+  '@fastify/rate-limit': 7.4.0
   '@fastify/redis': 6.0.0
   cheerio: 1.0.0-rc.12
   domhandler: 5.0.3
@@ -429,6 +431,14 @@ packages:
     resolution: {integrity: sha512-cTKBV2J9+u6VaKDhX7HepSfPSzw+F+TSd+k0wzifj4rG+4E5PjSFJCk19P8R6tr/72cuzgGd+mbB3jFT6lvAgw==}
     dependencies:
       fast-json-stringify: 5.2.0
+    dev: false
+
+  /@fastify/rate-limit/7.4.0:
+    resolution: {integrity: sha512-hIklIQgfoLLUde8Mp46/syfMXkLLi4DF3qVEkw9Hwsh3QwxwhQYV+P27uJIM4vG4K97TaqMq9xQNZT+BmrZFSQ==}
+    dependencies:
+      fastify-plugin: 4.2.1
+      ms: 2.1.3
+      tiny-lru: 8.0.2
     dev: false
 
   /@fastify/redis/6.0.0:
@@ -3366,7 +3376,6 @@ packages:
 
   /ms/2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-    dev: true
 
   /natural-compare/1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}

--- a/src/helpers/shared.ts
+++ b/src/helpers/shared.ts
@@ -7,7 +7,7 @@ import { PaprDocument } from '#config/typing/papr'
 import { ParsedObject } from '#config/typing/unions'
 
 class SharedHelper {
-	asin10Regex = /(?=.\d)[A-Z\d]{10}/
+	asin10Regex = /^(B[\dA-Z]{9}|\d{9}(X|\d))$/
 	asin11Regex = /(?=.\d)[A-Z\d]{11}/
 	/**
 	 * Creates URL to use in fetchBook

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,5 @@
 import cors from '@fastify/cors'
+import rateLimit from '@fastify/rate-limit'
 import redis from '@fastify/redis'
 import { fastify } from 'fastify'
 
@@ -20,7 +21,8 @@ const port = Number(process.env.PORT) || 3000
 const server = fastify({
 	logger: {
 		level: 'warn'
-	}
+	},
+	trustProxy: true
 })
 
 // Register routes
@@ -50,6 +52,12 @@ server.register(cors, {
 	origin: true
 })
 
+// Rate limiting
+server.register(rateLimit, {
+	global: true,
+	max: 100,
+	timeWindow: '1 minute'
+})
 server.listen({ port: port, host: host }, async (err, address) => {
 	if (err) {
 		console.error(err)

--- a/src/server.ts
+++ b/src/server.ts
@@ -25,16 +25,6 @@ const server = fastify({
 	trustProxy: true
 })
 
-// Register routes
-server
-	.register(showBook)
-	.register(deleteBook)
-	.register(showChapter)
-	.register(deleteChapter)
-	.register(showAuthor)
-	.register(deleteAuthor)
-	.register(searchAuthor)
-
 // Register redis if it's present
 if (process.env.REDIS_URL) {
 	console.log('Using Redis')
@@ -58,6 +48,24 @@ server.register(rateLimit, {
 	max: 100,
 	timeWindow: '1 minute'
 })
+// Send 429 if rate limit is reached
+server.setErrorHandler(function (error, _request, reply) {
+	if (reply.statusCode === 429) {
+		error.message = 'Rate limit reached. Please try again later.'
+	}
+	reply.send(error)
+})
+
+// Register routes
+server
+	.register(showBook)
+	.register(deleteBook)
+	.register(showChapter)
+	.register(deleteChapter)
+	.register(showAuthor)
+	.register(deleteAuthor)
+	.register(searchAuthor)
+
 server.listen({ port: port, host: host }, async (err, address) => {
 	if (err) {
 		console.error(err)

--- a/src/server.ts
+++ b/src/server.ts
@@ -49,7 +49,7 @@ server.register(cors, {
 // Rate limiting
 server.register(rateLimit, {
 	global: true,
-	max: 100,
+	max: Number(process.env.MAX_REQUESTS) || 100,
 	redis: process.env.REDIS_URL ? server.redis : undefined,
 	timeWindow: '1 minute'
 })

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,7 +28,11 @@ const server = fastify({
 // Register redis if it's present
 if (process.env.REDIS_URL) {
 	console.log('Using Redis')
-	server.register(redis, { url: process.env.REDIS_URL })
+	server.register(redis, {
+		connectTimeout: 500,
+		maxRetriesPerRequest: 1,
+		url: process.env.REDIS_URL
+	})
 }
 
 // Setup DB context
@@ -46,6 +50,7 @@ server.register(cors, {
 server.register(rateLimit, {
 	global: true,
 	max: 100,
+	redis: process.env.REDIS_URL ? server.redis : undefined,
 	timeWindow: '1 minute'
 })
 // Send 429 if rate limit is reached

--- a/tests/helpers/shared.test.ts
+++ b/tests/helpers/shared.test.ts
@@ -35,6 +35,10 @@ describe('SharedHelper should', () => {
 		expect(helper.checkAsinValidity('B079LRSMNN')).toBe(true)
 		expect(helper.checkAsinValidity('12345678910')).toBe(false)
 		expect(helper.checkAsinValidity('B*79LRSMNN')).toBe(false)
+		expect(helper.checkAsinValidity('20XORININE')).toBe(false)
+		expect(helper.checkAsinValidity('1705047572')).toBe(true)
+		expect(helper.checkAsinValidity('B07Q769RZS')).toBe(true)
+		expect(helper.checkAsinValidity('B0B9YP4F9P')).toBe(true)
 	})
 
 	test('check data equality', () => {


### PR DESCRIPTION
Recent investigations from https://github.com/laxamentumtech/audnexus/issues/479 performance issues caused me to find there is room for abuse of the public service:

- Enabling Cloudflare bot fight mode, would overzealously block Plex agents.
- There were tons of retries of invalid asins that matched the asin regex (and thus proceeded to try the request).
- A user could send as many requests as they wanted and Cloudlfare may not rate limit or block them.

This PR aims to address these issues by doing the following:

- Correctly process incoming IPs in a docker container (by trusting upstream proxy).
- Rate limit ALL routes if there are >100 requests within a minute by default. Allow adjusting this via environment var `MAX_REQUESTS`.
- Update the ASIN regex to be stricter, requiring it either stars with `B` (as a large number of early books use), or it is fully numeric (as all new books are).

Eventually rate limit repeated 404 or 400 attempts of different URLs, when this is resolved: https://github.com/fastify/fastify-rate-limit/issues/260