### PR TITLE
refactor: :recycle: use `quality=High` when getting chapter info

### DIFF
--- a/src/helpers/books/audible/ChapterHelper.ts
+++ b/src/helpers/books/audible/ChapterHelper.ts
@@ -28,7 +28,7 @@ class ChapterHelper {
 		const baseDomain = 'https://api.audible'
 		const regionTLD = regions[region].tld
 		const baseUrl = '1.0/content'
-		const params = 'response_groups=chapter_info'
+		const params = 'response_groups=chapter_info&quality=High'
 		this.requestUrl = helper.buildUrl(asin + '/metadata', baseDomain, regionTLD, baseUrl, params)
 	}
 

--- a/tests/datasets/audible/books/chapter.ts
+++ b/tests/datasets/audible/books/chapter.ts
@@ -24,122 +24,122 @@ export function setupParsedChapter(object: AudibleChapter, asin: string): ApiCha
 export const chapterResponseB017V4IM1G: AudibleChapter = {
 	content_metadata: {
 		chapter_info: {
-			brandIntroDurationMs: 2043,
-			brandOutroDurationMs: 5061,
+			brandIntroDurationMs: 3924,
+			brandOutroDurationMs: 4945,
 			chapters: [
-				{ length_ms: 29043, start_offset_ms: 0, start_offset_sec: 0, title: 'Opening Credits' },
+				{ length_ms: 30924, start_offset_ms: 0, start_offset_sec: 0, title: 'Opening Credits' },
 				{
-					length_ms: 1732701,
-					start_offset_ms: 29043,
-					start_offset_sec: 29,
+					length_ms: 1732654,
+					start_offset_ms: 30924,
+					start_offset_sec: 31,
 					title: 'Chapter 1: The Boy Who Lived'
 				},
 				{
-					length_ms: 1306447,
-					start_offset_ms: 1761744,
-					start_offset_sec: 1762,
+					length_ms: 1306377,
+					start_offset_ms: 1763578,
+					start_offset_sec: 1764,
 					title: 'Chapter 2: The Vanishing Glass'
 				},
 				{
-					length_ms: 1455705,
-					start_offset_ms: 3068191,
-					start_offset_sec: 3068,
+					length_ms: 1455635,
+					start_offset_ms: 3069955,
+					start_offset_sec: 3070,
 					title: 'Chapter 3: The Letters from No One'
 				},
 				{
-					length_ms: 1463600,
-					start_offset_ms: 4523896,
-					start_offset_sec: 4524,
+					length_ms: 1463530,
+					start_offset_ms: 4525590,
+					start_offset_sec: 4526,
 					title: 'Chapter 4: The Keeper of the Keys'
 				},
 				{
-					length_ms: 2635650,
-					start_offset_ms: 5987496,
-					start_offset_sec: 5987,
+					length_ms: 2635580,
+					start_offset_ms: 5989120,
+					start_offset_sec: 5989,
 					title: 'Chapter 5: Diagon Alley'
 				},
 				{
-					length_ms: 2294595,
-					start_offset_ms: 8623146,
-					start_offset_sec: 8623,
+					length_ms: 2294549,
+					start_offset_ms: 8624700,
+					start_offset_sec: 8625,
 					title: 'Chapter 6: The Journey from Platform Nine and Three-Quarters'
 				},
 				{
-					length_ms: 1729236,
-					start_offset_ms: 10917741,
-					start_offset_sec: 10918,
+					length_ms: 1729190,
+					start_offset_ms: 10919249,
+					start_offset_sec: 10919,
 					title: 'Chapter 7: The Sorting Hat'
 				},
 				{
-					length_ms: 1112607,
-					start_offset_ms: 12646977,
-					start_offset_sec: 12647,
+					length_ms: 1112537,
+					start_offset_ms: 12648439,
+					start_offset_sec: 12648,
 					title: 'Chapter 8: The Potions Master'
 				},
 				{
-					length_ms: 1858339,
-					start_offset_ms: 13759584,
-					start_offset_sec: 13760,
+					length_ms: 1858292,
+					start_offset_ms: 13760976,
+					start_offset_sec: 13761,
 					title: 'Chapter 9: The Midnight Duel'
 				},
 				{
-					length_ms: 1532609,
-					start_offset_ms: 15617923,
-					start_offset_sec: 15618,
+					length_ms: 1532563,
+					start_offset_ms: 15619268,
+					start_offset_sec: 15619,
 					title: "Chapter 10: Hallowe'en"
 				},
 				{
-					length_ms: 1274821,
-					start_offset_ms: 17150532,
-					start_offset_sec: 17151,
+					length_ms: 1274752,
+					start_offset_ms: 17151831,
+					start_offset_sec: 17152,
 					title: 'Chapter 11: Quidditch'
 				},
 				{
-					length_ms: 2138650,
-					start_offset_ms: 18425353,
-					start_offset_sec: 18425,
+					length_ms: 2138581,
+					start_offset_ms: 18426583,
+					start_offset_sec: 18427,
 					title: 'Chapter 12: The Mirror of Erised'
 				},
 				{
-					length_ms: 1187422,
-					start_offset_ms: 20564003,
-					start_offset_sec: 20564,
+					length_ms: 1187352,
+					start_offset_ms: 20565164,
+					start_offset_sec: 20565,
 					title: 'Chapter 13: Nicolas Flamel'
 				},
 				{
-					length_ms: 1275890,
-					start_offset_ms: 21751425,
-					start_offset_sec: 21751,
+					length_ms: 1275820,
+					start_offset_ms: 21752516,
+					start_offset_sec: 21753,
 					title: 'Chapter 14: Norbert the Norwegian Ridgeback'
 				},
 				{
-					length_ms: 1942024,
-					start_offset_ms: 23027315,
-					start_offset_sec: 23027,
+					length_ms: 1941954,
+					start_offset_ms: 23028336,
+					start_offset_sec: 23028,
 					title: 'Chapter 15: The Forbidden Forest'
 				},
 				{
-					length_ms: 2474086,
-					start_offset_ms: 24969339,
-					start_offset_sec: 24969,
+					length_ms: 2474016,
+					start_offset_ms: 24970290,
+					start_offset_sec: 24970,
 					title: 'Chapter 16: Through the Trapdoor'
 				},
 				{
-					length_ms: 2362258,
-					start_offset_ms: 27443425,
-					start_offset_sec: 27443,
+					length_ms: 2362189,
+					start_offset_ms: 27444306,
+					start_offset_sec: 27444,
 					title: 'Chapter 17: The Man with Two Faces'
 				},
 				{
-					length_ms: 102491,
-					start_offset_ms: 29805683,
+					length_ms: 102306,
+					start_offset_ms: 29806495,
 					start_offset_sec: 29806,
 					title: 'The Story Continues in Harry Potter and the Chamber of Secrets'
 				}
 			],
 			is_accurate: true,
-			runtime_length_ms: 29908174,
-			runtime_length_sec: 29908
+			runtime_length_ms: 29908801,
+			runtime_length_sec: 29909
 		}
 	},
 	response_groups: ['always-returned', 'chapter_info']
@@ -148,79 +148,79 @@ export const chapterResponseB017V4IM1G: AudibleChapter = {
 export const chapterResponseB08C6YJ1LS: AudibleChapter = {
 	content_metadata: {
 		chapter_info: {
-			brandIntroDurationMs: 1927,
-			brandOutroDurationMs: 4969,
+			brandIntroDurationMs: 3924,
+			brandOutroDurationMs: 4945,
 			chapters: [
 				{
-					length_ms: 21710,
+					length_ms: 23707,
 					start_offset_ms: 0,
 					start_offset_sec: 0,
 					title: 'Opening Credits'
 				},
 				{
 					length_ms: 1487424,
-					start_offset_ms: 21710,
-					start_offset_sec: 22,
+					start_offset_ms: 23707,
+					start_offset_sec: 24,
 					title: 'Episode 1'
 				},
 				{
 					length_ms: 1593330,
-					start_offset_ms: 1509134,
-					start_offset_sec: 1509,
+					start_offset_ms: 1511131,
+					start_offset_sec: 1511,
 					title: 'Episode 2'
 				},
 				{
 					length_ms: 1703067,
-					start_offset_ms: 3102464,
-					start_offset_sec: 3102,
+					start_offset_ms: 3104461,
+					start_offset_sec: 3104,
 					title: 'Episode 3'
 				},
 				{
 					length_ms: 2048464,
-					start_offset_ms: 4805531,
-					start_offset_sec: 4806,
+					start_offset_ms: 4807528,
+					start_offset_sec: 4808,
 					title: 'Episode 4'
 				},
 				{
 					length_ms: 1442887,
-					start_offset_ms: 6853995,
-					start_offset_sec: 6854,
+					start_offset_ms: 6855992,
+					start_offset_sec: 6856,
 					title: 'Episode 5'
 				},
 				{
 					length_ms: 1267716,
-					start_offset_ms: 8296882,
-					start_offset_sec: 8297,
+					start_offset_ms: 8298879,
+					start_offset_sec: 8299,
 					title: 'Episode 6'
 				},
 				{
 					length_ms: 1353793,
-					start_offset_ms: 9564598,
-					start_offset_sec: 9565,
+					start_offset_ms: 9566595,
+					start_offset_sec: 9567,
 					title: 'Episode 7'
 				},
 				{
 					length_ms: 1843617,
-					start_offset_ms: 10918391,
-					start_offset_sec: 10918,
+					start_offset_ms: 10920388,
+					start_offset_sec: 10920,
 					title: 'Episode 8'
 				},
 				{
 					length_ms: 952505,
-					start_offset_ms: 12762008,
-					start_offset_sec: 12762,
+					start_offset_ms: 12764005,
+					start_offset_sec: 12764,
 					title: 'Episode 9'
 				},
 				{
-					length_ms: 225024,
-					start_offset_ms: 13714513,
-					start_offset_sec: 13715,
+					length_ms: 225000,
+					start_offset_ms: 13716510,
+					start_offset_sec: 13717,
 					title: 'End Credits'
 				}
 			],
 			is_accurate: true,
-			runtime_length_ms: 13939537,
-			runtime_length_sec: 13940
+			runtime_length_ms: 13941510,
+			runtime_length_sec: 13942
 		}
 	},
 	response_groups: ['always-returned', 'chapter_info']
@@ -228,58 +228,58 @@ export const chapterResponseB08C6YJ1LS: AudibleChapter = {
 
 export const chapterParsed1721358595: ApiChapter = {
 	asin: '1721358595',
-	brandIntroDurationMs: 2043,
-	brandOutroDurationMs: 5061,
+	brandIntroDurationMs: 3924,
+	brandOutroDurationMs: 4945,
 	chapters: [
-		{ lengthMs: 21244, startOffsetMs: 0, startOffsetSec: 0, title: 'Opening Credits' },
-		{ lengthMs: 34400, startOffsetMs: 21244, startOffsetSec: 21, title: 'Epigraph' },
+		{ lengthMs: 23125, startOffsetMs: 0, startOffsetSec: 0, title: 'Opening Credits' },
+		{ lengthMs: 34400, startOffsetMs: 23125, startOffsetSec: 23, title: 'Epigraph' },
 		{
-			lengthMs: 83536,
-			startOffsetMs: 55644,
-			startOffsetSec: 56,
+			lengthMs: 83489,
+			startOffsetMs: 57525,
+			startOffsetSec: 58,
 			title: 'Tips for Throwing a Dinner Party at the End of the World'
 		},
 		{
 			lengthMs: 7448,
-			startOffsetMs: 139180,
-			startOffsetSec: 139,
+			startOffsetMs: 141014,
+			startOffsetSec: 141,
 			title: 'Part One: The Softest Invasion'
 		},
-		{ lengthMs: 292600, startOffsetMs: 146628, startOffsetSec: 147, title: 'Chapter 1' },
-		{ lengthMs: 1031151, startOffsetMs: 439228, startOffsetSec: 439, title: 'Chapter 2' },
-		{ lengthMs: 604183, startOffsetMs: 1470379, startOffsetSec: 1470, title: 'Chapter 3' },
-		{ lengthMs: 770167, startOffsetMs: 2074562, startOffsetSec: 2075, title: 'Chapter 4' },
+		{ lengthMs: 292600, startOffsetMs: 148462, startOffsetSec: 148, title: 'Chapter 1' },
+		{ lengthMs: 1031081, startOffsetMs: 441062, startOffsetSec: 441, title: 'Chapter 2' },
+		{ lengthMs: 604114, startOffsetMs: 1472143, startOffsetSec: 1472, title: 'Chapter 3' },
+		{ lengthMs: 770051, startOffsetMs: 2076257, startOffsetSec: 2076, title: 'Chapter 4' },
 		{
 			lengthMs: 0,
-			startOffsetMs: 2844729,
-			startOffsetSec: 2845,
+			startOffsetMs: 2846308,
+			startOffsetSec: 2846,
 			title: 'Part Two: So, Your True Love Has Become a Baby'
 		},
-		{ lengthMs: 1387435, startOffsetMs: 2081484, startOffsetSec: 2081, title: 'Chapter 5' },
-		{ lengthMs: 555189, startOffsetMs: 3468919, startOffsetSec: 3469, title: 'Chapter 6' },
-		{ lengthMs: 400172, startOffsetMs: 4024108, startOffsetSec: 4024, title: 'Chapter 7' },
-		{ lengthMs: 479166, startOffsetMs: 4424280, startOffsetSec: 4424, title: 'Chapter 8' },
-		{ lengthMs: 415172, startOffsetMs: 4903446, startOffsetSec: 4903, title: 'Chapter 9' },
-		{ lengthMs: 361163, startOffsetMs: 5318618, startOffsetSec: 5319, title: 'Chapter 10' },
-		{ lengthMs: 212183, startOffsetMs: 5679781, startOffsetSec: 5680, title: 'Chapter 11' },
-		{ lengthMs: 450188, startOffsetMs: 5891964, startOffsetSec: 5892, title: 'Chapter 12' },
-		{ lengthMs: 571164, startOffsetMs: 6342152, startOffsetSec: 6342, title: 'Chapter 13' },
-		{ lengthMs: 599324, startOffsetMs: 6913316, startOffsetSec: 6913, title: 'Chapter 14' },
+		{ lengthMs: 1387389, startOffsetMs: 2083109, startOffsetSec: 2083, title: 'Chapter 5' },
+		{ lengthMs: 555120, startOffsetMs: 3470498, startOffsetSec: 3470, title: 'Chapter 6' },
+		{ lengthMs: 400125, startOffsetMs: 4025618, startOffsetSec: 4026, title: 'Chapter 7' },
+		{ lengthMs: 479097, startOffsetMs: 4425743, startOffsetSec: 4426, title: 'Chapter 8' },
+		{ lengthMs: 415103, startOffsetMs: 4904840, startOffsetSec: 4905, title: 'Chapter 9' },
+		{ lengthMs: 361117, startOffsetMs: 5319943, startOffsetSec: 5320, title: 'Chapter 10' },
+		{ lengthMs: 212136, startOffsetMs: 5681060, startOffsetSec: 5681, title: 'Chapter 11' },
+		{ lengthMs: 450119, startOffsetMs: 5893196, startOffsetSec: 5893, title: 'Chapter 12' },
+		{ lengthMs: 571094, startOffsetMs: 6343315, startOffsetSec: 6343, title: 'Chapter 13' },
+		{ lengthMs: 599208, startOffsetMs: 6914409, startOffsetSec: 6914, title: 'Chapter 14' },
 		{
 			lengthMs: 4298,
-			startOffsetMs: 7512640,
-			startOffsetSec: 7513,
+			startOffsetMs: 7513617,
+			startOffsetSec: 7514,
 			title: 'Part Three: You Can (Never) Go Home Again'
 		},
-		{ lengthMs: 1041743, startOffsetMs: 7516938, startOffsetSec: 7517, title: 'Chapter 15' },
-		{ lengthMs: 508191, startOffsetMs: 8558681, startOffsetSec: 8559, title: 'Chapter 16' },
-		{ lengthMs: 1104201, startOffsetMs: 9066872, startOffsetSec: 9067, title: 'Chapter 17' },
-		{ lengthMs: 223190, startOffsetMs: 10171073, startOffsetSec: 10171, title: 'Chapter 18' },
-		{ lengthMs: 632213, startOffsetMs: 10394263, startOffsetSec: 10394, title: 'Epilogue' },
-		{ lengthMs: 61271, startOffsetMs: 11026476, startOffsetSec: 11026, title: 'End Credits' }
+		{ lengthMs: 1041743, startOffsetMs: 7517915, startOffsetSec: 7518, title: 'Chapter 15' },
+		{ lengthMs: 508145, startOffsetMs: 8559658, startOffsetSec: 8560, title: 'Chapter 16' },
+		{ lengthMs: 1104132, startOffsetMs: 9067803, startOffsetSec: 9068, title: 'Chapter 17' },
+		{ lengthMs: 223121, startOffsetMs: 10171935, startOffsetSec: 10172, title: 'Chapter 18' },
+		{ lengthMs: 632074, startOffsetMs: 10395056, startOffsetSec: 10395, title: 'Epilogue' },
+		{ lengthMs: 61109, startOffsetMs: 11027130, startOffsetSec: 11027, title: 'End Credits' }
 	],
 	isAccurate: true,
 	region: 'us',
-	runtimeLengthMs: 11087747,
+	runtimeLengthMs: 11088239,
 	runtimeLengthSec: 11088
 }

--- a/tests/datasets/helpers/chapters.ts
+++ b/tests/datasets/helpers/chapters.ts
@@ -11,168 +11,33 @@ export const apiChapters: AudibleChapter = {
 			brandIntroDurationMs: 2043,
 			brandOutroDurationMs: 5062,
 			chapters: [
-				{
-					length_ms: 21073,
-					start_offset_ms: 0,
-					start_offset_sec: 0,
-					title: 'Legionnaire'
-				},
-				{
-					length_ms: 1591,
-					start_offset_ms: 21073,
-					start_offset_sec: 21,
-					title: 'Part One'
-				},
-				{
-					length_ms: 945561,
-					start_offset_ms: 22664,
-					start_offset_sec: 23,
-					title: '1'
-				},
-				{
-					length_ms: 1198150,
-					start_offset_ms: 968225,
-					start_offset_sec: 968,
-					title: '2'
-				},
-				{
-					length_ms: 843488,
-					start_offset_ms: 2166375,
-					start_offset_sec: 2166,
-					title: '3'
-				},
-				{
-					length_ms: 868287,
-					start_offset_ms: 3009863,
-					start_offset_sec: 3010,
-					title: '4'
-				},
-				{
-					length_ms: 973845,
-					start_offset_ms: 3878150,
-					start_offset_sec: 3878,
-					title: '5'
-				},
-				{
-					length_ms: 1257964,
-					start_offset_ms: 4851995,
-					start_offset_sec: 4852,
-					title: '6'
-				},
-				{
-					length_ms: 1150549,
-					start_offset_ms: 6109959,
-					start_offset_sec: 6110,
-					title: '7'
-				},
-				{
-					length_ms: 793844,
-					start_offset_ms: 7260508,
-					start_offset_sec: 7261,
-					title: '8'
-				},
-				{
-					length_ms: 1101183,
-					start_offset_ms: 8054352,
-					start_offset_sec: 8054,
-					title: '9'
-				},
-				{
-					length_ms: 1169310,
-					start_offset_ms: 9155535,
-					start_offset_sec: 9156,
-					title: '10'
-				},
-				{
-					length_ms: 990610,
-					start_offset_ms: 10324845,
-					start_offset_sec: 10325,
-					title: '11'
-				},
-				{
-					length_ms: 500,
-					start_offset_ms: 11315455,
-					start_offset_sec: 11315,
-					title: 'Camp Forge'
-				},
-				{
-					length_ms: 582553,
-					start_offset_ms: 11315955,
-					start_offset_sec: 11316,
-					title: '12'
-				},
-				{
-					length_ms: 3504,
-					start_offset_ms: 11898508,
-					start_offset_sec: 11899,
-					title: 'Part Two'
-				},
-				{
-					length_ms: 1007168,
-					start_offset_ms: 11902012,
-					start_offset_sec: 11902,
-					title: '13'
-				},
-				{
-					length_ms: 927359,
-					start_offset_ms: 12909180,
-					start_offset_sec: 12909,
-					title: '14'
-				},
-				{
-					length_ms: 1053164,
-					start_offset_ms: 13836539,
-					start_offset_sec: 13837,
-					title: '15'
-				},
-				{
-					length_ms: 775825,
-					start_offset_ms: 14889703,
-					start_offset_sec: 14890,
-					title: '16'
-				},
-				{
-					length_ms: 868566,
-					start_offset_ms: 15665528,
-					start_offset_sec: 15666,
-					title: '17'
-				},
-				{
-					length_ms: 1087158,
-					start_offset_ms: 16534094,
-					start_offset_sec: 16534,
-					title: '18'
-				},
-				{
-					length_ms: 1085719,
-					start_offset_ms: 17621252,
-					start_offset_sec: 17621,
-					title: '19'
-				},
-				{
-					length_ms: 784881,
-					start_offset_ms: 18706971,
-					start_offset_sec: 18707,
-					title: '20'
-				},
-				{
-					length_ms: 1570644,
-					start_offset_ms: 19491852,
-					start_offset_sec: 19492,
-					title: '21'
-				},
-				{
-					length_ms: 1286803,
-					start_offset_ms: 21062496,
-					start_offset_sec: 21062,
-					title: '22'
-				},
-				{
-					length_ms: 856166,
-					start_offset_ms: 22349299,
-					start_offset_sec: 22349,
-					title: '23'
-				},
+				{ length_ms: 21073, start_offset_ms: 0, start_offset_sec: 0, title: 'Legionnaire' },
+				{ length_ms: 1591, start_offset_ms: 21073, start_offset_sec: 21, title: 'Part One' },
+				{ length_ms: 945561, start_offset_ms: 22664, start_offset_sec: 23, title: '1' },
+				{ length_ms: 1198150, start_offset_ms: 968225, start_offset_sec: 968, title: '2' },
+				{ length_ms: 843488, start_offset_ms: 2166375, start_offset_sec: 2166, title: '3' },
+				{ length_ms: 868287, start_offset_ms: 3009863, start_offset_sec: 3010, title: '4' },
+				{ length_ms: 973845, start_offset_ms: 3878150, start_offset_sec: 3878, title: '5' },
+				{ length_ms: 1257964, start_offset_ms: 4851995, start_offset_sec: 4852, title: '6' },
+				{ length_ms: 1150549, start_offset_ms: 6109959, start_offset_sec: 6110, title: '7' },
+				{ length_ms: 793844, start_offset_ms: 7260508, start_offset_sec: 7261, title: '8' },
+				{ length_ms: 1101183, start_offset_ms: 8054352, start_offset_sec: 8054, title: '9' },
+				{ length_ms: 1169310, start_offset_ms: 9155535, start_offset_sec: 9156, title: '10' },
+				{ length_ms: 990610, start_offset_ms: 10324845, start_offset_sec: 10325, title: '11' },
+				{ length_ms: 500, start_offset_ms: 11315455, start_offset_sec: 11315, title: 'Camp Forge' },
+				{ length_ms: 582553, start_offset_ms: 11315955, start_offset_sec: 11316, title: '12' },
+				{ length_ms: 3504, start_offset_ms: 11898508, start_offset_sec: 11899, title: 'Part Two' },
+				{ length_ms: 1007168, start_offset_ms: 11902012, start_offset_sec: 11902, title: '13' },
+				{ length_ms: 927359, start_offset_ms: 12909180, start_offset_sec: 12909, title: '14' },
+				{ length_ms: 1053164, start_offset_ms: 13836539, start_offset_sec: 13837, title: '15' },
+				{ length_ms: 775825, start_offset_ms: 14889703, start_offset_sec: 14890, title: '16' },
+				{ length_ms: 868566, start_offset_ms: 15665528, start_offset_sec: 15666, title: '17' },
+				{ length_ms: 1087158, start_offset_ms: 16534094, start_offset_sec: 16534, title: '18' },
+				{ length_ms: 1085719, start_offset_ms: 17621252, start_offset_sec: 17621, title: '19' },
+				{ length_ms: 784881, start_offset_ms: 18706971, start_offset_sec: 18707, title: '20' },
+				{ length_ms: 1570644, start_offset_ms: 19491852, start_offset_sec: 19492, title: '21' },
+				{ length_ms: 1286803, start_offset_ms: 21062496, start_offset_sec: 21062, title: '22' },
+				{ length_ms: 856166, start_offset_ms: 22349299, start_offset_sec: 22349, title: '23' },
 				{
 					length_ms: 2788252,
 					start_offset_ms: 23205465,
@@ -185,198 +50,38 @@ export const apiChapters: AudibleChapter = {
 					start_offset_sec: 25994,
 					title: 'Galactic Outlaws'
 				},
-				{
-					length_ms: 1142375,
-					start_offset_ms: 26612389,
-					start_offset_sec: 26612,
-					title: '1'
-				},
-				{
-					length_ms: 880547,
-					start_offset_ms: 27754764,
-					start_offset_sec: 27755,
-					title: '2'
-				},
-				{
-					length_ms: 1227175,
-					start_offset_ms: 28635311,
-					start_offset_sec: 28635,
-					title: '3'
-				},
-				{
-					length_ms: 541814,
-					start_offset_ms: 29862486,
-					start_offset_sec: 29862,
-					title: '4'
-				},
-				{
-					length_ms: 589880,
-					start_offset_ms: 30404300,
-					start_offset_sec: 30404,
-					title: '5'
-				},
-				{
-					length_ms: 1030316,
-					start_offset_ms: 30994180,
-					start_offset_sec: 30994,
-					title: '6'
-				},
-				{
-					length_ms: 1358600,
-					start_offset_ms: 32024496,
-					start_offset_sec: 32024,
-					title: '7'
-				},
-				{
-					length_ms: 1502099,
-					start_offset_ms: 33383096,
-					start_offset_sec: 33383,
-					title: '8'
-				},
-				{
-					length_ms: 1581883,
-					start_offset_ms: 34885195,
-					start_offset_sec: 34885,
-					title: '9'
-				},
-				{
-					length_ms: 1139264,
-					start_offset_ms: 36467078,
-					start_offset_sec: 36467,
-					title: '10'
-				},
-				{
-					length_ms: 1295999,
-					start_offset_ms: 37606342,
-					start_offset_sec: 37606,
-					title: '11'
-				},
-				{
-					length_ms: 1341556,
-					start_offset_ms: 38902341,
-					start_offset_sec: 38902,
-					title: '12'
-				},
-				{
-					length_ms: 1233537,
-					start_offset_ms: 40243897,
-					start_offset_sec: 40244,
-					title: '13'
-				},
-				{
-					length_ms: 982715,
-					start_offset_ms: 41477434,
-					start_offset_sec: 41477,
-					title: '14'
-				},
-				{
-					length_ms: 2074424,
-					start_offset_ms: 42460149,
-					start_offset_sec: 42460,
-					title: '15'
-				},
-				{
-					length_ms: 1307191,
-					start_offset_ms: 44534573,
-					start_offset_sec: 44535,
-					title: '16'
-				},
-				{
-					length_ms: 1750413,
-					start_offset_ms: 45841764,
-					start_offset_sec: 45842,
-					title: '17'
-				},
-				{
-					length_ms: 1449993,
-					start_offset_ms: 47592177,
-					start_offset_sec: 47592,
-					title: '18'
-				},
-				{
-					length_ms: 1149899,
-					start_offset_ms: 49042170,
-					start_offset_sec: 49042,
-					title: '19'
-				},
-				{
-					length_ms: 1361200,
-					start_offset_ms: 50192069,
-					start_offset_sec: 50192,
-					title: '20'
-				},
-				{
-					length_ms: 1272546,
-					start_offset_ms: 51553269,
-					start_offset_sec: 51553,
-					title: '21'
-				},
-				{
-					length_ms: 1227314,
-					start_offset_ms: 52825815,
-					start_offset_sec: 52826,
-					title: '22'
-				},
-				{
-					length_ms: 1570551,
-					start_offset_ms: 54053129,
-					start_offset_sec: 54053,
-					title: '23'
-				},
-				{
-					length_ms: 966043,
-					start_offset_ms: 55623680,
-					start_offset_sec: 55624,
-					title: '24'
-				},
-				{
-					length_ms: 883751,
-					start_offset_ms: 56589723,
-					start_offset_sec: 56590,
-					title: '25'
-				},
-				{
-					length_ms: 843999,
-					start_offset_ms: 57473474,
-					start_offset_sec: 57473,
-					title: '26'
-				},
-				{
-					length_ms: 926569,
-					start_offset_ms: 58317473,
-					start_offset_sec: 58317,
-					title: '27'
-				},
-				{
-					length_ms: 696784,
-					start_offset_ms: 59244042,
-					start_offset_sec: 59244,
-					title: '28'
-				},
-				{
-					length_ms: 594988,
-					start_offset_ms: 59940826,
-					start_offset_sec: 59941,
-					title: '29'
-				},
-				{
-					length_ms: 417495,
-					start_offset_ms: 60535814,
-					start_offset_sec: 60536,
-					title: '30'
-				},
-				{
-					length_ms: 1469356,
-					start_offset_ms: 60953309,
-					start_offset_sec: 60953,
-					title: '31'
-				},
-				{
-					length_ms: 89614,
-					start_offset_ms: 62422665,
-					start_offset_sec: 62423,
-					title: 'Epilogue'
-				},
+				{ length_ms: 1142375, start_offset_ms: 26612389, start_offset_sec: 26612, title: '1' },
+				{ length_ms: 880547, start_offset_ms: 27754764, start_offset_sec: 27755, title: '2' },
+				{ length_ms: 1227175, start_offset_ms: 28635311, start_offset_sec: 28635, title: '3' },
+				{ length_ms: 541814, start_offset_ms: 29862486, start_offset_sec: 29862, title: '4' },
+				{ length_ms: 589880, start_offset_ms: 30404300, start_offset_sec: 30404, title: '5' },
+				{ length_ms: 1030316, start_offset_ms: 30994180, start_offset_sec: 30994, title: '6' },
+				{ length_ms: 1358600, start_offset_ms: 32024496, start_offset_sec: 32024, title: '7' },
+				{ length_ms: 1502099, start_offset_ms: 33383096, start_offset_sec: 33383, title: '8' },
+				{ length_ms: 1581883, start_offset_ms: 34885195, start_offset_sec: 34885, title: '9' },
+				{ length_ms: 1139264, start_offset_ms: 36467078, start_offset_sec: 36467, title: '10' },
+				{ length_ms: 1295999, start_offset_ms: 37606342, start_offset_sec: 37606, title: '11' },
+				{ length_ms: 1341556, start_offset_ms: 38902341, start_offset_sec: 38902, title: '12' },
+				{ length_ms: 1233537, start_offset_ms: 40243897, start_offset_sec: 40244, title: '13' },
+				{ length_ms: 982715, start_offset_ms: 41477434, start_offset_sec: 41477, title: '14' },
+				{ length_ms: 2074424, start_offset_ms: 42460149, start_offset_sec: 42460, title: '15' },
+				{ length_ms: 1307191, start_offset_ms: 44534573, start_offset_sec: 44535, title: '16' },
+				{ length_ms: 1750413, start_offset_ms: 45841764, start_offset_sec: 45842, title: '17' },
+				{ length_ms: 1449993, start_offset_ms: 47592177, start_offset_sec: 47592, title: '18' },
+				{ length_ms: 1149899, start_offset_ms: 49042170, start_offset_sec: 49042, title: '19' },
+				{ length_ms: 1361200, start_offset_ms: 50192069, start_offset_sec: 50192, title: '20' },
+				{ length_ms: 1272546, start_offset_ms: 51553269, start_offset_sec: 51553, title: '21' },
+				{ length_ms: 1227314, start_offset_ms: 52825815, start_offset_sec: 52826, title: '22' },
+				{ length_ms: 1570551, start_offset_ms: 54053129, start_offset_sec: 54053, title: '23' },
+				{ length_ms: 966043, start_offset_ms: 55623680, start_offset_sec: 55624, title: '24' },
+				{ length_ms: 883751, start_offset_ms: 56589723, start_offset_sec: 56590, title: '25' },
+				{ length_ms: 843999, start_offset_ms: 57473474, start_offset_sec: 57473, title: '26' },
+				{ length_ms: 926569, start_offset_ms: 58317473, start_offset_sec: 58317, title: '27' },
+				{ length_ms: 696784, start_offset_ms: 59244042, start_offset_sec: 59244, title: '28' },
+				{ length_ms: 594988, start_offset_ms: 59940826, start_offset_sec: 59941, title: '29' },
+				{ length_ms: 417495, start_offset_ms: 60535814, start_offset_sec: 60536, title: '30' },
+				{ length_ms: 1469356, start_offset_ms: 60953309, start_offset_sec: 60953, title: '31' },
+				{ length_ms: 89614, start_offset_ms: 62422665, start_offset_sec: 62423, title: 'Epilogue' },
 				{
 					length_ms: 35730,
 					start_offset_ms: 62512279,

--- a/tests/helpers/books/audible/ChapterHelper.test.ts
+++ b/tests/helpers/books/audible/ChapterHelper.test.ts
@@ -21,7 +21,7 @@ beforeEach(() => {
 	// Variables
 	asin = 'B079LRSMNN'
 	region = 'us'
-	url = `https://api.audible.com/1.0/content/${asin}/metadata?response_groups=chapter_info`
+	url = `https://api.audible.com/1.0/content/${asin}/metadata?response_groups=chapter_info&quality=High`
 	mockResponse = deepCopy(apiChapters)
 	// Set up spys
 	jest.spyOn(SharedHelper.prototype, 'buildUrl').mockReturnValue(url)


### PR DESCRIPTION
Following the discussion here: https://github.com/djdembeck/m4b-merge/pull/166

It looks like we can get 'better' chapter timings when setting `qualtiy` param in API requests. This is likely to be the timings people are looking for when they download books from their account.

This would do well to be merged before v1.5.0, so that the update task can update chapters as well: https://github.com/laxamentumtech/audnexus/pull/636