### PR TITLE
ci(workflows): replace paths-ignore with selective changes classifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,13 @@
 # Circuit-breaker CI pipeline.
-# Chain: lint-format -> build -> test -> docker-build
-# Each stage gates on the previous; a failure short-circuits downstream jobs.
+# Selective chain: changes -> {workflow-lint, lint-format -> build -> test -> docker-build}
+# The `changes` classifier always runs and emits per-concern flags; each concern job
+# skips when its flag is false, accepting upstream `skipped` (never bare `always()`/`failure()`).
 
 name: CI
 
 on:
   push:
     branches: [main, develop]
-    paths-ignore: ['*.md', 'docs/**']
   pull_request:
   workflow_dispatch:
 
@@ -19,7 +19,147 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      # Fail-open: if the classifier step dies before writing its outputs, the
+      # job-level 'true' defaults keep the full chain running (never a silent all-skip).
+      workflow: ${{ steps.classify.outputs.workflow || 'true' }}
+      lint: ${{ steps.classify.outputs.lint || 'true' }}
+      build: ${{ steps.classify.outputs.build || 'true' }}
+      test: ${{ steps.classify.outputs.test || 'true' }}
+      docker: ${{ steps.classify.outputs.docker || 'true' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Classify changed paths
+        id: classify
+        if: always()
+        # Fail-open: every concern defaults to true and is narrowed only after a
+        # confirmed, non-empty, successfully-read diff. Any failure path (zero or
+        # unresolvable base, dispatch, unexpected event, git-diff error, empty
+        # diff) leaves all five true -> full chain. classify is the last step, so a
+        # genuine crash makes THIS job red (loud), never a green silent all-skip.
+        run: |
+          set -uo pipefail
+          WORKFLOW=true
+          LINT=true
+          BUILD=true
+          TEST=true
+          DOCKER=true
+          FAILSAFE=""
+
+          DIFF_FILE="$(mktemp)"
+          trap 'rm -f "$DIFF_FILE"' EXIT
+
+          CLASSIFY=false
+          case "${{ github.event_name }}" in
+            pull_request)
+              BASE="${{ github.event.pull_request.base.sha }}"
+              HEAD="${{ github.event.pull_request.head.sha }}"
+              CLASSIFY=true
+              ;;
+            push)
+              BASE="${{ github.event.before }}"
+              HEAD="${{ github.sha }}"
+              CLASSIFY=true
+              if [ -z "$BASE" ] || ! git rev-parse --verify -q "${BASE}^{commit}" >/dev/null 2>&1; then
+                CLASSIFY=false
+                FAILSAFE="push base missing/zero/unresolvable"
+              fi
+              ;;
+            workflow_dispatch)
+              FAILSAFE="manual dispatch: no diff to classify"
+              ;;
+            *)
+              FAILSAFE="unexpected event '${{ github.event_name }}'"
+              ;;
+          esac
+
+          if [ "$CLASSIFY" = true ]; then
+            if git diff --name-only -z --no-renames "$BASE" "$HEAD" > "$DIFF_FILE" 2>/dev/null; then
+              WORKFLOW=false
+              LINT=false
+              BUILD=false
+              TEST=false
+              DOCKER=false
+              SAW_PATH=false
+              while IFS= read -r -d '' path; do
+                SAW_PATH=true
+                case "$path" in
+                  .github/workflows/*.yml|.github/workflows/*.yaml) WORKFLOW=true ;;
+                  Dockerfile|.dockerignore|docker-compose.yml|docker-compose.develop.yml) DOCKER=true ;;
+                  src/*) LINT=true; BUILD=true; TEST=true; DOCKER=true ;;
+                  tests/live/*) : ;;
+                  tests/*) LINT=true; TEST=true ;;
+                  *.md|docs/*|renovate.json5|.pre-commit-config.yaml|.gitignore|.editorconfig|LICENSE|.env.example|.coderabbit.yaml|.sisyphus/*|.nvmrc) : ;;
+                  package.json|bun.lock|.npmrc) LINT=true; BUILD=true; TEST=true; DOCKER=true; ;;
+                  package-lock.json|shrinkwrap.yaml) LINT=true; BUILD=true; TEST=true; DOCKER=true; FAILSAFE="npm artifact (only-allow bun forbids these); full run to expose it" ;;
+                  bunfig.toml) TEST=true ;;
+                  tsconfig.json) LINT=true; BUILD=true ;;
+                  eslint.config.mjs|.prettierrc|.prettierignore) LINT=true ;;
+                  scripts/*) DOCKER=true ;;
+                  *) LINT=true; BUILD=true; TEST=true; DOCKER=true ;;
+                esac
+              done < "$DIFF_FILE"
+              if [ "$SAW_PATH" = false ]; then
+                WORKFLOW=true
+                LINT=true
+                BUILD=true
+                TEST=true
+                DOCKER=true
+                FAILSAFE="empty diff"
+              fi
+            else
+              FAILSAFE="git diff failed (base=$BASE head=$HEAD)"
+            fi
+          fi
+
+          {
+            echo "workflow=${WORKFLOW}"
+            echo "lint=${LINT}"
+            echo "build=${BUILD}"
+            echo "test=${TEST}"
+            echo "docker=${DOCKER}"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "### Selective CI classification"
+            echo ""
+            echo "| Concern | Flag |"
+            echo "|---|---|"
+            echo "| workflow | ${WORKFLOW} |"
+            echo "| lint | ${LINT} |"
+            echo "| build | ${BUILD} |"
+            echo "| test | ${TEST} |"
+            echo "| docker | ${DOCKER} |"
+            if [ -n "$FAILSAFE" ]; then
+              echo ""
+              echo "Fail-safe full run: ${FAILSAFE}"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  workflow-lint:
+    needs: [changes]
+    if: ${{ !cancelled() && needs['changes'].outputs.workflow == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: stable
+
+      - name: Lint workflows with actionlint
+        run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+
   lint-format:
+    needs: [changes]
+    if: ${{ !cancelled() && needs['changes'].outputs.lint == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -35,7 +175,8 @@ jobs:
       - run: bun run lint:check
 
   build:
-    needs: [lint-format]
+    needs: [changes, workflow-lint, lint-format]
+    if: ${{ !cancelled() && needs['changes'].outputs.build == 'true' && (needs['workflow-lint'].result == 'success' || needs['workflow-lint'].result == 'skipped') && (needs['lint-format'].result == 'success' || needs['lint-format'].result == 'skipped') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -51,7 +192,8 @@ jobs:
       - run: bun run build
 
   test:
-    needs: [build]
+    needs: [changes, workflow-lint, lint-format, build]
+    if: ${{ !cancelled() && needs['changes'].outputs.test == 'true' && (needs['workflow-lint'].result == 'success' || needs['workflow-lint'].result == 'skipped') && (needs['lint-format'].result == 'success' || needs['lint-format'].result == 'skipped') && (needs['build'].result == 'success' || needs['build'].result == 'skipped') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -67,8 +209,8 @@ jobs:
       - run: bun run test
 
   docker-build:
-    needs: [test]
-    if: success()
+    needs: [changes, workflow-lint, lint-format, build, test]
+    if: ${{ !cancelled() && needs['changes'].outputs.docker == 'true' && (needs['workflow-lint'].result == 'success' || needs['workflow-lint'].result == 'skipped') && (needs['lint-format'].result == 'success' || needs['lint-format'].result == 'skipped') && (needs['build'].result == 'success' || needs['build'].result == 'skipped') && (needs['test'].result == 'success' || needs['test'].result == 'skipped') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,26 @@ jobs:
           go-version: stable
 
       - name: Lint workflows with actionlint
-        run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+        # Scoped to the changed workflow files so pre-existing findings in
+        # untouched workflows can't fail this gate. When the base is unknown
+        # (new-branch first push, dispatch) or the diff carries no workflow
+        # changes, linting is skipped: a fresh branch's workflow content is
+        # still diffed against the default branch by the pull_request event.
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          PATHS=""
+          if [ -n "${BASE_SHA}" ] && [ "${BASE_SHA}" != "0000000000000000000000000000000000000000" ] \
+            && git rev-parse --verify -q "${BASE_SHA}^{commit}" >/dev/null 2>&1; then
+            PATHS=$(git diff --name-only --no-renames "$BASE_SHA" "$HEAD_SHA" \
+              | grep -E '^\.github/workflows/.*\.ya?ml$' || true)
+          fi
+          if [ -n "$PATHS" ]; then
+            go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 $PATHS
+          else
+            echo "No resolvable base with changed workflow files (first push or dispatch) — skipping workflow lint"
+          fi
 
   lint-format:
     needs: [changes]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,13 +93,13 @@ jobs:
                   .github/workflows/*.yml|.github/workflows/*.yaml) WORKFLOW=true ;;
                   Dockerfile|.dockerignore|docker-compose.yml|docker-compose.develop.yml) DOCKER=true ;;
                   src/*) LINT=true; BUILD=true; TEST=true; DOCKER=true ;;
-                  tests/live/*) : ;;
+                  tests/live/*) LINT=true ;;
                   tests/*) LINT=true; TEST=true ;;
                   *.md|docs/*|renovate.json5|.pre-commit-config.yaml|.gitignore|.editorconfig|LICENSE|.env.example|.coderabbit.yaml|.sisyphus/*|.nvmrc) : ;;
                   package.json|bun.lock|.npmrc) LINT=true; BUILD=true; TEST=true; DOCKER=true; ;;
                   package-lock.json|shrinkwrap.yaml) LINT=true; BUILD=true; TEST=true; DOCKER=true; FAILSAFE="npm artifact (only-allow bun forbids these); full run to expose it" ;;
-                  bunfig.toml) TEST=true ;;
-                  tsconfig.json) LINT=true; BUILD=true ;;
+                  bunfig.toml) LINT=true; BUILD=true; TEST=true; DOCKER=true ;;
+                  tsconfig.json) LINT=true; BUILD=true; TEST=true; DOCKER=true ;;
                   eslint.config.mjs|.prettierrc|.prettierignore) LINT=true ;;
                   scripts/*) DOCKER=true ;;
                   *) LINT=true; BUILD=true; TEST=true; DOCKER=true ;;
@@ -169,7 +169,7 @@ jobs:
             && git rev-parse --verify -q "${BASE_SHA}^{commit}" >/dev/null 2>&1; then
             while IFS= read -r p; do
               PATHS+=("$p")
-            done < <(git diff --name-only --no-renames "$BASE_SHA" "$HEAD_SHA" \
+            done < <(git diff --name-only --diff-filter=ACM --no-renames "$BASE_SHA" "$HEAD_SHA" \
               | grep -E '^\.github/workflows/.*\.ya?ml$' || true)
           fi
           if [ "${#PATHS[@]}" -gt 0 ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,14 +164,16 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
-          PATHS=""
+          PATHS=()
           if [ -n "${BASE_SHA}" ] && [ "${BASE_SHA}" != "0000000000000000000000000000000000000000" ] \
             && git rev-parse --verify -q "${BASE_SHA}^{commit}" >/dev/null 2>&1; then
-            PATHS=$(git diff --name-only --no-renames "$BASE_SHA" "$HEAD_SHA" \
+            while IFS= read -r p; do
+              PATHS+=("$p")
+            done < <(git diff --name-only --no-renames "$BASE_SHA" "$HEAD_SHA" \
               | grep -E '^\.github/workflows/.*\.ya?ml$' || true)
           fi
-          if [ -n "$PATHS" ]; then
-            go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 $PATHS
+          if [ "${#PATHS[@]}" -gt 0 ]; then
+            go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 "${PATHS[@]}"
           else
             echo "No resolvable base with changed workflow files (first push or dispatch) — skipping workflow lint"
           fi

--- a/.github/workflows/deploy-coolify.yml
+++ b/.github/workflows/deploy-coolify.yml
@@ -11,13 +11,31 @@ jobs:
   deploy:
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_branch == 'main'
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      actions: read
 
     steps:
+      - name: Decide whether a fresh Docker image shipped
+        id: image-check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CI_RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          CONCLUSION=$(gh api "/repos/${GITHUB_REPOSITORY}/actions/runs/${CI_RUN_ID}/jobs" --paginate \
+            --jq '.jobs[] | select(.name == "docker-build") | .conclusion' | tail -n1)
+          if [ "${CONCLUSION:-}" = "success" ]; then
+            echo "deploy=true"  >> "$GITHUB_OUTPUT"
+          else
+            echo "CI run ${CI_RUN_ID}: docker-build=${CONCLUSION:-absent} — not deploying"
+            echo "deploy=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Deploy to Coolify
+        if: steps.image-check.outputs.deploy == 'true'
         run: |
           response_body=$(mktemp)
           response=$(curl -s -o "$response_body" -w "%{http_code}" --max-time 30 --request GET '${{ secrets.COOLIFY_WEBHOOK }}' \


### PR DESCRIPTION
## Summary
CI no longer runs the full lint → build → test → Docker chain for changes that can't affect any of it. An always-run `changes` job classifies the diff and emits per-concern flags; only the concerns actually touched run. Docs-only changes now finish in a single lightweight green job instead of either triggering the entire ~2–4 min chain + Docker build (feature branches) or producing no CI run at all (`main`/`develop`).

## Motivation
Today's `paths-ignore: ['*.md', 'docs/**']` on `on.push` is only partial and unfair: a docs change to `main`/`develop` gets no CI feedback at all, while the identical change on a feature branch buys the whole chain. Meanwhile every other inert path — `.github/**` workflow edits, `renovate.json5`, `.pre-commit-config.yaml`, `LICENSE`, `.gitignore` — still triggers the full chain plus a Docker build whose output depends on nothing that changed. This PR replaces the event-level filter with a cheap in-repo classifier that routes each change to exactly the concerns it affects.

## Changes
- `ci.yml`: new always-run `changes` job first (no Bun, no install) that NUL-safely diffs the change (`git diff --name-only -z --no-renames`) and emits `workflow`/`lint`/`build`/`test`/`docker` flags with a per-concern table in the step summary. Event-aware base/head: PR base vs head, push `before` vs `sha`, dispatch = full run.
- New `workflow-lint` job: actionlint (pinned `@v1.7.12` via Go module) lints only the workflow files in the diff, so pre-existing findings in untouched workflows can't fail the gate; when no resolvable base exists (first push, dispatch) it skips with a log line. No Bun install bought anywhere.
- Concern jobs rewired onto the flags with skip-safe gates (`success || skipped` acceptance of every upstream), so a skipped upstream never blocks a legitimately admitted downstream. All step bodies, action pins, the Docker tag matrix, fork guard, and PR comment behavior are byte-identical.
- **Fail-open classifier**: any error path — zero/unresolvable push base, empty diff, git-diff failure, unexpected event, or a crash before outputs are written — runs the full chain. Job-level output defaults (`|| 'true'`) mean even a dead classifier can never silently skip a concern; the worst case is a red `changes` job plus a full run, never a green no-op.
- `deploy-coolify.yml`: because CI now always runs on `main`, the `workflow_run` hook fires for docs-only pushes too (today they fire no run, so no deploy — correct by accident). The deploy job gains a fork guard, `actions: read`, and a guard step that queries the CI run's jobs and only calls the Coolify webhook when `docker-build` concluded `success` (docs-only → job absent/skipped → step skipped, no webhook egress; source change → deploys exactly as today).

## Notes
- **Verified live**: this PR's own run exercises the workflow-only row of the change matrix — `changes` pass, `workflow-lint` pass (scoped actionlint on the two edited workflows), `lint-format`/`build`/`test`/`docker-build` all skipped, run conclusion green, and the whole pipeline finishes in seconds with no Bun install.
- **Verified locally**: actionlint v1.7.12 clean on both edited workflows; classifier loop exercised against a real git repo for all 18 change-matrix cases (docs-only, workflow-only, lint-config-only, test-only, docker-only, source, deps, tsconfig, bunfig, unknown path, npm-artifact, rename `src/→tests/`, empty diff, zero/unresolvable base, dispatch); scoped actionlint step exercised for single/multi-file diffs, zero/unresolvable base, dispatch, and src-only diffs; deploy guard exercised for success/skipped/absent/failed/paginated job queries.
- **Not yet verified live**: the other PR walkthroughs (docs-only PR → single green job; Dockerfile-only PR → `changes` + `docker-build`; src PR → full chain + `pr-N` image), the main-branch deploy egress check (docs-only merge → `Deploy to Coolify` step skipped, no webhook call). The main-merge deploy no-op is best observed on the next real docs merge since it touches the live Coolify webhook.
- First live run failed `workflow-lint` on pre-existing shellcheck findings in `pr-cleanup.yml`/`release.yml` — the exact legacy debt this PR exists to stop paying for. Resolved by scoping actionlint to the changed workflow files (follow-up commit on this branch).
- Known deviation from the reference design: classifier failure is fail-open at the *job* level (outputs default `true`, no `needs['changes'].result == 'success'` gate in the concern predicates) rather than the reference's success-gated form, which would have produced a green `changes` job + silent all-skip on a classifier crash — contradicting the "never a silent all-skip" requirement.
- Pre-existing, unrelated: `tests/audible/books/stitch.test.ts` fails on the branch base (Audible fixture drift — description/image/tags for `B017V4IM1G` changed upstream). It will fail this PR's `Test` job independently of these workflow changes; the `bun-test` pre-commit hook fails on the base commit as well.
- `release.yml` (fill_after release cut on `main`) keeps its own event-level `paths-ignore` by design; `live-tests.yml`, `deploy-docs.yml`, `conventional-commits.yml`, `pr-cleanup.yml` are untouched. Tag pushes remain out of `ci.yml` scope so release images are still built only by `release.yml`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI checks to run the appropriate validation steps for changed files, with full validation used when changes cannot be classified reliably.
  * Added workflow syntax validation coverage.
  * Prevented deployments unless CI completes successfully on the main branch and the Docker build passes.
  * Removed the exclusion that allowed documentation-only pushes to bypass CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->